### PR TITLE
Add video_format_description getter

### DIFF
--- a/src/capture_device.rs
+++ b/src/capture_device.rs
@@ -1,6 +1,6 @@
 use core_foundation::base::TCFType;
 use core_media::{
-    format_description::{CMFormatDescription, CMFormatDescriptionRef},
+    format_description::{CMFormatDescription, CMFormatDescriptionRef, CMVideoFormatDescription},
     time::CMTime,
 };
 use objc2::{extern_class, msg_send, msg_send_id, mutability::InteriorMutable, rc::Id, ClassType};
@@ -277,6 +277,13 @@ impl AVCaptureDeviceFormat {
         unsafe {
             let format_description: CMFormatDescriptionRef = msg_send![self, formatDescription];
             CMFormatDescription::wrap_under_get_rule(format_description)
+        }
+    }
+
+    pub fn video_format_description(&self) -> CMVideoFormatDescription {
+        unsafe {
+            let format_description: CMFormatDescriptionRef = msg_send![self, videoFormatDescription];
+            CMVideoFormatDescription::wrap_under_get_rule(format_description)
         }
     }
 

--- a/src/capture_device.rs
+++ b/src/capture_device.rs
@@ -282,7 +282,7 @@ impl AVCaptureDeviceFormat {
 
     pub fn video_format_description(&self) -> CMVideoFormatDescription {
         unsafe {
-            let format_description: CMFormatDescriptionRef = msg_send![self, videoFormatDescription];
+            let format_description: CMFormatDescriptionRef = msg_send![self, formatDescription];
             CMVideoFormatDescription::wrap_under_get_rule(format_description)
         }
     }


### PR DESCRIPTION
So that we can query dimensions from this object when capturing video.

Is there a better way to make this polymorphic?